### PR TITLE
Fix `MANIA_PREPLUS` and `MANIA_FIRST_RELEASE` define checks

### DIFF
--- a/C/GameAPI/Game.h
+++ b/C/GameAPI/Game.h
@@ -60,26 +60,34 @@
 #if GAME_IS_MANIA
 #define VER_100 (0) // 1.00 (initial console release)
 #define VER_103 (3) // 1.03 (PC release/console patch)
-#define VER_105 (5) // 1.04/1.05
+#define VER_105 (5) // 1.04/1.05 (mania plus release)
 #define VER_106 (6) // 1.06 (steam denuvo removal update)
 #define VER_107 (7) // 1.07 (EGS/Origin releases)
 
-#ifdef MANIA_PREPLUS
+#if MANIA_PREPLUS
 
-#ifdef MANIA_FIRST_RELEASE
+#if MANIA_FIRST_RELEASE
+
+#undef GAME_VERSION
 #define GAME_VERSION VER_100
+#undef RETRO_REVISION
+#define RETRO_REVISION (0)
+
 #else
-#ifndef GAME_VERSION
+	
+#undef GAME_VERSION
 #define GAME_VERSION VER_103
-#endif
+#undef RETRO_REVISION
+#define RETRO_REVISION (1)
+
 #endif
 
-#undef RETRO_REV02
-#define RETRO_REV02 (0)
 #else
+
 #ifndef GAME_VERSION
 #define GAME_VERSION VER_106
 #endif
+
 #endif
 
 #define MANIA_USE_PLUS (GAME_VERSION >= VER_105)
@@ -87,12 +95,38 @@
 
 #elif GAME_IS_S3
 #define VER_100 (0) // 1.00 (initial origins release)
-#define VER_104 (4) // 1.04 (origins' first patch)
+#define VER_104 (1) // 1.04 (origins' first patch)
+#define VER_200 (2) // 2.00 (origins plus release)
+#define VER_201 (3) // 1.04 (origins plus august 2023 patch)
+
+#if ORIGINS_PREPLUS
+
+#if ORIGINS_FIRST_RELEASE
+
+#undef GAME_VERSION
+#define GAME_VERSION VER_100
+
+#else
+	
+#undef GAME_VERSION
+#define GAME_VERSION VER_104
+
+#endif
+
+#else
 
 #ifndef GAME_VERSION
-#define GAME_VERSION VER_104
+#define GAME_VERSION VER_201
 #endif
-#else 
+
+#endif
+
+#define ORIGINS_USE_PLUS (GAME_VERSION >= VER_200)
+
+#undef RETRO_REVISION
+#define RETRO_REVISION (3)
+#else
+// None Gametype
 #define VER_100 (0)
 
 #ifndef GAME_VERSION

--- a/CPP/GameAPI/Game.hpp
+++ b/CPP/GameAPI/Game.hpp
@@ -31,22 +31,30 @@
 #define VER_106 (6) // 1.06 (steam denuvo removal update)
 #define VER_107 (7) // 1.07 (EGS/Origin releases)
 
-#ifdef MANIA_PREPLUS
+#if MANIA_PREPLUS
 
-#ifdef MANIA_FIRST_RELEASE
+#if MANIA_FIRST_RELEASE
+
+#undef GAME_VERSION
 #define GAME_VERSION VER_100
+#undef RETRO_REVISION
+#define RETRO_REVISION (0)
+
 #else
-#ifndef GAME_VERSION
+	
+#undef GAME_VERSION
 #define GAME_VERSION VER_103
-#endif
+#undef RETRO_REVISION
+#define RETRO_REVISION (1)
+
 #endif
 
-#undef RETRO_REV02
-#define RETRO_REV02 (0)
 #else
+
 #ifndef GAME_VERSION
 #define GAME_VERSION VER_106
 #endif
+
 #endif
 
 #define MANIA_USE_PLUS (GAME_VERSION >= VER_105)
@@ -54,12 +62,38 @@
 
 #elif GAME_IS_S3
 #define VER_100 (0) // 1.00 (initial origins release)
-#define VER_104 (4) // 1.04 (origins' first patch)
+#define VER_104 (1) // 1.04 (origins' first patch)
+#define VER_200 (2) // 2.00 (origins plus release)
+#define VER_201 (3) // 1.04 (origins plus august 2023 patch)
+
+#if ORIGINS_PREPLUS
+
+#if ORIGINS_FIRST_RELEASE
+
+#undef GAME_VERSION
+#define GAME_VERSION VER_100
+
+#else
+	
+#undef GAME_VERSION
+#define GAME_VERSION VER_104
+
+#endif
+
+#else
 
 #ifndef GAME_VERSION
-#define GAME_VERSION VER_104
+#define GAME_VERSION VER_201
 #endif
+
+#endif
+
+#define ORIGINS_USE_PLUS (GAME_VERSION >= VER_200)
+
+#undef RETRO_REVISION
+#define RETRO_REVISION (3)
 #else
+// None Gametype
 #define VER_100 (0)
 
 #ifndef GAME_VERSION


### PR DESCRIPTION
These flags weren't being checked if they were enabled, only defined, causing GameAPI to always try to build for version 1.00 when built with CMake flags set up. Also added Origins Plus versions and define checks for S3.