### PR TITLE
[C++] Improvements for the C++ ModAPI interface

### DIFF
--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -72,8 +72,35 @@ namespace Mod
 // Mod Callbacks & Public Functions
 inline void AddModCallback(int32 callbackID, void (*callback)(void *)) { modTable->AddModCallback(callbackID, callback); }
 inline void AddModCallback(int32 callbackID, std::function<void(void *)> callback) { modTable->AddModCallback_STD(callbackID, callback); }
-inline void AddPublicFunction(const char *functionName, void *functionPtr) { modTable->AddPublicFunction(functionName, functionPtr); }
-inline void *GetPublicFunction(const char *id, const char *functionName) { return modTable->GetPublicFunction(id, functionName); }
+
+namespace PublicFunctions
+{
+struct FunctionObject {
+    const char *id;
+    const char *functionName;
+
+    template <typename T> inline operator T() const { return reinterpret_cast<T>(modTable->GetPublicFunction(id, functionName)); }
+};
+
+template <typename obj, typename R> inline void Add(const char *functionName, R(obj::*functionPtr))
+{
+    modTable->AddPublicFunction(functionName, reinterpret_cast<void *&>(functionPtr));
+}
+
+template <typename R> inline void Add(const char *functionName, R(*functionPtr))
+{
+    modTable->AddPublicFunction(functionName, reinterpret_cast<void *&>(functionPtr));
+}
+
+inline FunctionObject Get(const char *id, const char *functionName) { return { id, functionName }; }
+
+#if RETRO_MOD_LOADER_VER >= 3
+inline void Hook(const char *id, const char *functionName, void *functionPtr, void **originalPtr)
+{
+    modTable->HookPublicFunction(id, functionName, functionPtr, originalPtr);
+}
+#endif
+} // namespace PublicFunctions
 
 // Shaders
 inline void LoadShader(const char *shaderName, bool32 linear) { modTable->LoadShader(shaderName, linear); }
@@ -133,7 +160,6 @@ inline bool32 GetBool(const char *key, bool32 fallback) { return modTable->GetCo
 inline int32 GetInteger(const char *key, int32 fallback) { return modTable->GetConfigInteger(key, fallback); }
 inline float GetFloat(const char *key, float fallback) { return modTable->GetConfigFloat(key, fallback); }
 inline void GetString(const char *key, String *result, const char *fallback) { modTable->GetConfigString(key, result, fallback); }
-
 } // namespace Config
 
 #if RETRO_MOD_LOADER_VER >= 2
@@ -169,7 +195,6 @@ inline void *GetModel(uint16 id) { return modTable->GetModel(id); }
 inline void *GetScene3D(uint16 id) { return modTable->GetScene3D(id); }
 inline void *GetSfx(uint16 id) { return modTable->GetSfx(id); }
 inline void *GetChannel(uint8 id) { return modTable->GetChannel(id); }
-
 } // namespace Engine
 #endif
 
@@ -181,18 +206,13 @@ inline void RegisterStateHook(void (*state)(), bool32 (*hook)(bool32 skippedStat
 extern const char *modID;
 
 #if RETRO_MOD_LOADER_VER >= 3
-inline void HookPublicFunction(const char *id, const char *functionName, void *functionPtr, void **originalPtr)
-{
-    modTable->HookPublicFunction(id, functionName, functionPtr, originalPtr);
-}
-
 // FIXME: Find a more C++ way of handling it, struct/namespace?
 
 // Generic hook
 #define DEFINE_PUBLIC_HOOK_FUNC(modID, name, returnType, ...)                                                                                        \
     static returnType (*Original_##name)(__VA_ARGS__);                                                                                               \
     static returnType Hook_##name(__VA_ARGS__);                                                                                                      \
-    static void RegisterHook_##name(void) { HookPublicFunction(modID, #name, Hook_##name, (void **)&Original_##name); }                              \
+    static void RegisterHook_##name(void) { Mod::PublicFunctions::Hook(modID, #name, Hook_##name, (void **)&Original_##name); }                      \
     static returnType Hook_##name(__VA_ARGS__)
 
 // Hook into the current game's public functions

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -252,20 +252,6 @@ template <auto hook> void RegisterStateHook(void (*state)(), bool32 priority)
     }
 }
 
-template <auto hook, typename T> void RegisterStateHook(void (*state)(T *self), bool32 priority)
-{
-    if constexpr (std::is_member_function_pointer_v<decltype(hook)>) {
-        static constexpr bool32 (*_hook)(bool32) = [](bool32 skippedState) -> bool32 {
-            return (reinterpret_cast<T *>(sceneInfo->entity)->*hook)(skippedState);
-        };
-
-        modTable->RegisterStateHook(reinterpret_cast<void (*)()>(state), _hook, priority);
-    }
-    else {
-        modTable->RegisterStateHook(reinterpret_cast<void (*)()>(state), hook, priority);
-    }
-}
-
 inline void RegisterStateHook(void (*state)(), bool32 (*hook)(bool32 skippedState), bool32 priority)
 {
     modTable->RegisterStateHook(state, hook, priority);

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -96,6 +96,47 @@ struct FunctionObject {
     }
 };
 
+#if RETRO_MOD_LOADER_VER >= 3
+template <typename Derived> class HookContainer
+{
+public:
+    constexpr HookContainer(const char *name)
+    {
+        this->modID__ = nullptr;
+        this->name__  = name;
+    }
+
+    constexpr HookContainer(const char *modID, const char *name)
+    {
+        this->modID__ = modID;
+        this->name__  = name;
+    }
+
+    static void Register() { Derived().Internal_Register(); }
+
+    template <typename... Args> static decltype(auto) Original(Args &&...args) { return Internal_Original()(std::forward<Args>(args)...); }
+
+protected:
+    const char *modID__;
+    const char *name__;
+
+    void Internal_Register()
+    {
+        auto &original = Internal_Original();
+
+        Hook(this->modID__, this->name__, reinterpret_cast<void *>(&Derived::Implementation), reinterpret_cast<void **>(&original));
+    }
+
+    static auto &Internal_Original()
+    {
+        using T = decltype(&Derived::Implementation);
+
+        static typename function_info<T>::signature *original = nullptr;
+        return original;
+    }
+};
+#endif
+
 template <typename obj, typename R> inline void Add(const char *functionName, R(obj::*functionPtr))
 {
     modTable->AddPublicFunction(functionName, reinterpret_cast<void *&>(functionPtr));
@@ -212,9 +253,14 @@ inline void *GetChannel(uint8 id) { return modTable->GetChannel(id); }
 } // namespace Engine
 #endif
 
-template <typename> struct func_get_object_type;
-template <typename T, typename returning, typename... args> struct func_get_object_type<returning (T::*)(args...)> {
-    using type = T;
+template <typename> struct function_info;
+template <typename T, typename Returning, typename... Args> struct function_info<Returning (T::*)(Args...)> {
+    using object_type = T;
+    using signature   = Returning(Args...);
+};
+
+template <typename Returning, typename... Args> struct function_info<Returning (*)(Args...)> {
+    using signature = Returning(Args...);
 };
 
 template <auto hook, typename T> void RegisterStateHook(void (T::*state)(), bool32 priority)
@@ -239,7 +285,7 @@ template <auto hook, typename T> void RegisterStateHook(void (T::*state)(), bool
 template <auto hook> void RegisterStateHook(void (*state)(), bool32 priority)
 {
     if constexpr (std::is_member_function_pointer_v<decltype(hook)>) {
-        using T = typename func_get_object_type<decltype(hook)>::type;
+        using T = typename function_info<decltype(hook)>::object_type;
 
         static constexpr bool32 (*_hook)(bool32) = [](bool32 skippedState) -> bool32 {
             return (reinterpret_cast<T *>(sceneInfo->entity)->*hook)(skippedState);
@@ -258,29 +304,6 @@ inline void RegisterStateHook(void (*state)(), bool32 (*hook)(bool32 skippedStat
 }
 
 extern const char *modID;
-
-#if RETRO_MOD_LOADER_VER >= 3
-// FIXME: Find a more C++ way of handling it, struct/namespace?
-
-// Generic hook
-#define DEFINE_PUBLIC_HOOK_FUNC(modID, name, returnType, ...)                                                                                        \
-    static returnType (*Original_##name)(__VA_ARGS__);                                                                                               \
-    static returnType Hook_##name(__VA_ARGS__);                                                                                                      \
-    static void RegisterHook_##name(void) { Mod::PublicFunctions::Hook(modID, #name, Hook_##name, (void **)&Original_##name); }                      \
-    static returnType Hook_##name(__VA_ARGS__)
-
-// Hook into the current game's public functions
-#define DEFINE_GAME_HOOK_FUNC(name, returnType, ...) DEFINE_PUBLIC_HOOK_FUNC(NULL, name, returnType, __VA_ARGS__)
-
-// Hook into other mods' public functions by ID
-#define DEFINE_MOD_HOOK_FUNC(modID, name, returnType, ...) DEFINE_PUBLIC_HOOK_FUNC(modID, name, returnType, __VA_ARGS__)
-
-// Register a defined hook of the same name
-#define REGISTER_HOOK_FUNC(name)                                                                                                                     \
-    do {                                                                                                                                             \
-        RegisterHook_##name();                                                                                                                       \
-    } while (0)
-#endif
 
 } // namespace Mod
 

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -5,6 +5,7 @@
 
 #if RETRO_USE_MOD_LOADER
 #include <functional>
+#include <type_traits>
 
 namespace RSDK
 {
@@ -79,7 +80,20 @@ struct FunctionObject {
     const char *id;
     const char *functionName;
 
-    template <typename T> inline operator T() const { return reinterpret_cast<T>(modTable->GetPublicFunction(id, functionName)); }
+    template <typename T> inline operator T() const
+    {
+        if constexpr (std::is_member_function_pointer_v<T>) {
+            union {
+                void *in;
+                T out;
+            } u;
+            u.in = modTable->GetPublicFunction(id, functionName);
+            return u.out;
+        }
+        else {
+            return reinterpret_cast<T>(modTable->GetPublicFunction(id, functionName));
+        }
+    }
 };
 
 template <typename obj, typename R> inline void Add(const char *functionName, R(obj::*functionPtr))

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -2,6 +2,8 @@
 
 #include "../Types.hpp"
 #include "../EngineAPI.hpp"
+#include "../Game/Object.hpp"
+#include "../Game/Stage.hpp"
 
 #if RETRO_USE_MOD_LOADER
 #include <functional>
@@ -96,47 +98,6 @@ struct FunctionObject {
     }
 };
 
-#if RETRO_MOD_LOADER_VER >= 3
-template <typename Derived> class HookContainer
-{
-public:
-    constexpr HookContainer(const char *name)
-    {
-        this->modID__ = nullptr;
-        this->name__  = name;
-    }
-
-    constexpr HookContainer(const char *modID, const char *name)
-    {
-        this->modID__ = modID;
-        this->name__  = name;
-    }
-
-    static void Register() { Derived().Internal_Register(); }
-
-    template <typename... Args> static decltype(auto) Original(Args &&...args) { return Internal_Original()(std::forward<Args>(args)...); }
-
-protected:
-    const char *modID__;
-    const char *name__;
-
-    void Internal_Register()
-    {
-        auto &original = Internal_Original();
-
-        Hook(this->modID__, this->name__, reinterpret_cast<void *>(&Derived::Implementation), reinterpret_cast<void **>(&original));
-    }
-
-    static auto &Internal_Original()
-    {
-        using T = decltype(&Derived::Implementation);
-
-        static typename function_info<T>::signature *original = nullptr;
-        return original;
-    }
-};
-#endif
-
 template <typename obj, typename R> inline void Add(const char *functionName, R(obj::*functionPtr))
 {
     modTable->AddPublicFunction(functionName, reinterpret_cast<void *&>(functionPtr));
@@ -154,6 +115,41 @@ inline void Hook(const char *id, const char *functionName, void *functionPtr, vo
 {
     modTable->HookPublicFunction(id, functionName, functionPtr, originalPtr);
 }
+
+template <typename Derived> class HookContainer
+{
+public:
+    constexpr HookContainer(const char *name)
+    {
+        this->modID__ = nullptr;
+        this->name__  = name;
+    }
+
+    constexpr HookContainer(const char *modID, const char *name)
+    {
+        this->modID__ = modID;
+        this->name__  = name;
+    }
+
+    static void Register()
+    {
+        Derived instance = {};
+        PublicFunctions::Hook(instance.modID__, instance.name__, reinterpret_cast<void *>(&Derived::Implementation), reinterpret_cast<void **>(&instance.original__));
+    }
+
+    template <typename... Args> static decltype(auto) Original(Args &&...args)
+    {
+        using T = decltype(&std::remove_reference_t<Derived>::Implementation);
+
+        T _original = reinterpret_cast<T>(original__);
+        return _original(std::forward<Args>(args)...);
+    }
+
+protected:
+    const char *modID__;
+    const char *name__;
+    inline static void *original__ = nullptr;
+};
 #endif
 } // namespace PublicFunctions
 
@@ -254,13 +250,13 @@ inline void *GetChannel(uint8 id) { return modTable->GetChannel(id); }
 #endif
 
 template <typename> struct function_info;
-template <typename T, typename Returning, typename... Args> struct function_info<Returning (T::*)(Args...)> {
+template <typename T, typename returning, typename... Args> struct function_info<returning (T::*)(Args...)> {
     using object_type = T;
-    using signature   = Returning(Args...);
+    using signature   = returning(Args...);
 };
 
-template <typename Returning, typename... Args> struct function_info<Returning (*)(Args...)> {
-    using signature = Returning(Args...);
+template <typename returning, typename... Args> struct function_info<returning (*)(Args...)> {
+    using signature = returning(Args...);
 };
 
 template <auto hook, typename T> void RegisterStateHook(void (T::*state)(), bool32 priority)
@@ -271,31 +267,20 @@ template <auto hook, typename T> void RegisterStateHook(void (T::*state)(), bool
     } u;
     u.in = state;
 
-    if constexpr (std::is_member_function_pointer_v<decltype(hook)>) {
-        static constexpr bool32 (*_hook)(bool32) = [](bool32 skippedState) -> bool32 {
-            return (reinterpret_cast<T *>(sceneInfo->entity)->*hook)(skippedState);
-        };
-        modTable->RegisterStateHook(u.out, _hook, priority);
-    }
-    else {
+    if constexpr (std::is_member_function_pointer_v<decltype(hook)>)
+        modTable->RegisterStateHook(u.out, +[](bool32 skippedState) -> bool32 { return ((T *)sceneInfo->entity->*hook)(skippedState); }, priority);
+    else
         modTable->RegisterStateHook(u.out, hook, priority);
-    }
 }
 
 template <auto hook> void RegisterStateHook(void (*state)(), bool32 priority)
 {
-    if constexpr (std::is_member_function_pointer_v<decltype(hook)>) {
-        using T = typename function_info<decltype(hook)>::object_type;
+    using T = typename function_info<decltype(hook)>::object_type;
 
-        static constexpr bool32 (*_hook)(bool32) = [](bool32 skippedState) -> bool32 {
-            return (reinterpret_cast<T *>(sceneInfo->entity)->*hook)(skippedState);
-        };
-
-        modTable->RegisterStateHook(state, _hook, priority);
-    }
-    else {
+    if constexpr (std::is_member_function_pointer_v<decltype(hook)>)
+        modTable->RegisterStateHook(state, +[](bool32 skippedState) -> bool32 { return ((T *)sceneInfo->entity->*hook)(skippedState); }, priority);
+    else
         modTable->RegisterStateHook(state, hook, priority);
-    }
 }
 
 inline void RegisterStateHook(void (*state)(), bool32 (*hook)(bool32 skippedState), bool32 priority)
@@ -308,5 +293,27 @@ extern const char *modID;
 } // namespace Mod
 
 } // namespace RSDK
+
+#if RETRO_MOD_LOADER_VER >= 3
+// Declare a generic hook
+#define DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, ...)                                                                                 \
+    struct type : Mod::PublicFunctions::HookContainer<type> {                                                                                        \
+        type() : HookContainer(modID, name) {}                                                                                                       \
+        static returnType Implementation(__VA_ARGS__);                                                                                               \
+    };
+
+// Declare a generic hook, hook into the current game's public functions
+#define DECLARE_GAME_HOOK_FUNC(name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(nullptr, name, type, returnType, __VA_ARGS__)
+
+// Declare a generic hook, hook into other mods' public functions by ID
+#define DECLARE_MOD_HOOK_FUNC(modID, name, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, __VA_ARGS__)
+
+// Define a generic hook
+#define DEFINE_PUBLIC_HOOK_FUNC(name, returnType, ...) returnType name::Implementation(__VA_ARGS__)
+
+// Register a defined hook of the same name
+#define REGISTER_HOOK_FUNC(name) name::Register();
+
+#endif // !RETRO_MOD_LOADER_VER
 
 #endif

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -47,10 +47,10 @@ enum ModSuper {
 
 #if RETRO_MOD_LOADER_VER >= 3
 enum RetroPlatform {
-    RETRO_WIN     = 0,
-    RETRO_PS4     = 1,
-    RETRO_XB1     = 2,
-    RETRO_SWITCH  = 3,
+    RETRO_WIN    = 0,
+    RETRO_PS4    = 1,
+    RETRO_XB1    = 2,
+    RETRO_SWITCH = 3,
     // CUSTOM
     RETRO_OSX     = 4,
     RETRO_LINUX   = 5,
@@ -79,7 +79,7 @@ inline void *GetPublicFunction(const char *id, const char *functionName) { retur
 inline void LoadShader(const char *shaderName, bool32 linear) { modTable->LoadShader(shaderName, linear); }
 
 // Misc
-inline void *GetGlobals() { return modTable->GetGlobals(); }
+template <typename T> inline T *GetGlobals() { return (T *)modTable->GetGlobals(); }
 
 #if RETRO_MOD_LOADER_VER >= 3
 inline void OpenModMenu() { modTable->OpenModMenu(); }
@@ -189,12 +189,10 @@ inline void HookPublicFunction(const char *id, const char *functionName, void *f
 // FIXME: Find a more C++ way of handling it, struct/namespace?
 
 // Generic hook
-#define DEFINE_PUBLIC_HOOK_FUNC(modID, name, returnType, ...)                        \
-    static returnType (*Original_##name)(__VA_ARGS__);                               \
-    static returnType Hook_##name(__VA_ARGS__);                                      \
-    static void RegisterHook_##name(void) {                                          \
-        HookPublicFunction(modID, #name, Hook_##name, (void**)&Original_##name);     \
-    }                                                                                \
+#define DEFINE_PUBLIC_HOOK_FUNC(modID, name, returnType, ...)                                                                                        \
+    static returnType (*Original_##name)(__VA_ARGS__);                                                                                               \
+    static returnType Hook_##name(__VA_ARGS__);                                                                                                      \
+    static void RegisterHook_##name(void) { HookPublicFunction(modID, #name, Hook_##name, (void **)&Original_##name); }                              \
     static returnType Hook_##name(__VA_ARGS__)
 
 // Hook into the current game's public functions
@@ -204,7 +202,10 @@ inline void HookPublicFunction(const char *id, const char *functionName, void *f
 #define DEFINE_MOD_HOOK_FUNC(modID, name, returnType, ...) DEFINE_PUBLIC_HOOK_FUNC(modID, name, returnType, __VA_ARGS__)
 
 // Register a defined hook of the same name
-#define REGISTER_HOOK_FUNC(name) do { RegisterHook_##name(); } while (0)
+#define REGISTER_HOOK_FUNC(name)                                                                                                                     \
+    do {                                                                                                                                             \
+        RegisterHook_##name();                                                                                                                       \
+    } while (0)
 #endif
 
 } // namespace Mod

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -212,6 +212,60 @@ inline void *GetChannel(uint8 id) { return modTable->GetChannel(id); }
 } // namespace Engine
 #endif
 
+template <typename> struct func_get_object_type;
+template <typename T, typename returning, typename... args> struct func_get_object_type<returning (T::*)(args...)> {
+    using type = T;
+};
+
+template <auto hook, typename T> void RegisterStateHook(void (T::*state)(), bool32 priority)
+{
+    union {
+        void (T::*in)();
+        void (*out)();
+    } u;
+    u.in = state;
+
+    if constexpr (std::is_member_function_pointer_v<decltype(hook)>) {
+        static constexpr bool32 (*_hook)(bool32) = [](bool32 skippedState) -> bool32 {
+            return (reinterpret_cast<T *>(sceneInfo->entity)->*hook)(skippedState);
+        };
+        modTable->RegisterStateHook(u.out, _hook, priority);
+    }
+    else {
+        modTable->RegisterStateHook(u.out, hook, priority);
+    }
+}
+
+template <auto hook> void RegisterStateHook(void (*state)(), bool32 priority)
+{
+    if constexpr (std::is_member_function_pointer_v<decltype(hook)>) {
+        using T = typename func_get_object_type<decltype(hook)>::type;
+
+        static constexpr bool32 (*_hook)(bool32) = [](bool32 skippedState) -> bool32 {
+            return (reinterpret_cast<T *>(sceneInfo->entity)->*hook)(skippedState);
+        };
+
+        modTable->RegisterStateHook(state, _hook, priority);
+    }
+    else {
+        modTable->RegisterStateHook(state, hook, priority);
+    }
+}
+
+template <auto hook, typename T> void RegisterStateHook(void (*state)(T *self), bool32 priority)
+{
+    if constexpr (std::is_member_function_pointer_v<decltype(hook)>) {
+        static constexpr bool32 (*_hook)(bool32) = [](bool32 skippedState) -> bool32 {
+            return (reinterpret_cast<T *>(sceneInfo->entity)->*hook)(skippedState);
+        };
+
+        modTable->RegisterStateHook(reinterpret_cast<void (*)()>(state), _hook, priority);
+    }
+    else {
+        modTable->RegisterStateHook(reinterpret_cast<void (*)()>(state), hook, priority);
+    }
+}
+
 inline void RegisterStateHook(void (*state)(), bool32 (*hook)(bool32 skippedState), bool32 priority)
 {
     modTable->RegisterStateHook(state, hook, priority);

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -252,11 +252,6 @@ inline void *GetChannel(uint8 id) { return modTable->GetChannel(id); }
 template <typename> struct function_info;
 template <typename T, typename returning, typename... Args> struct function_info<returning (T::*)(Args...)> {
     using object_type = T;
-    using signature   = returning(Args...);
-};
-
-template <typename returning, typename... Args> struct function_info<returning (*)(Args...)> {
-    using signature = returning(Args...);
 };
 
 template <auto hook, typename T> void RegisterStateHook(void (T::*state)(), bool32 priority)

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -301,7 +301,7 @@ extern const char *modID;
 #define DECLARE_GAME_HOOK_FUNC(name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(nullptr, name, type, returnType, __VA_ARGS__)
 
 // Declare a generic hook, hook into other mods' public functions by ID
-#define DECLARE_MOD_HOOK_FUNC(modID, name, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, __VA_ARGS__)
+#define DECLARE_MOD_HOOK_FUNC(modID, name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, __VA_ARGS__)
 
 // Define a generic hook
 #define DEFINE_PUBLIC_HOOK_FUNC(name, returnType, ...) returnType name::Implementation(__VA_ARGS__)

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -283,7 +283,7 @@ extern const char *modID;
 // Declare a generic hook
 #define DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, ...)                                                                                 \
     struct type : RSDK::Mod::PublicFunctions::HookContainer<type> {                                                                                        \
-        type() : HookContainer(modID, name) {}                                                                                                       \
+        type() : HookContainer(name, modID) {}                                                                                                       \
         static returnType Implementation(__VA_ARGS__);                                                                                               \
     };
 

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -292,7 +292,7 @@ extern const char *modID;
 #if RETRO_MOD_LOADER_VER >= 3
 // Declare a generic hook
 #define DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, ...)                                                                                 \
-    struct type : Mod::PublicFunctions::HookContainer<type> {                                                                                        \
+    struct type : RSDK::Mod::PublicFunctions::HookContainer<type> {                                                                                        \
         type() : HookContainer(modID, name) {}                                                                                                       \
         static returnType Implementation(__VA_ARGS__);                                                                                               \
     };

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -119,17 +119,7 @@ inline void Hook(const char *id, const char *functionName, void *functionPtr, vo
 template <typename Derived> class HookContainer
 {
 public:
-    constexpr HookContainer(const char *name)
-    {
-        this->modID__ = nullptr;
-        this->name__  = name;
-    }
-
-    constexpr HookContainer(const char *modID, const char *name)
-    {
-        this->modID__ = modID;
-        this->name__  = name;
-    }
+    constexpr HookContainer(const char *name, const char *modID = nullptr) : name__(name), modID__(modID) {}
 
     static void Register()
     {

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -307,7 +307,7 @@ extern const char *modID;
 #define DEFINE_PUBLIC_HOOK_FUNC(name, returnType, ...) returnType name::Implementation(__VA_ARGS__)
 
 // Register a defined hook of the same name
-#define REGISTER_HOOK_FUNC(name) name::Register();
+#define REGISTER_HOOK_FUNC(name) name::Register()
 
 #endif // !RETRO_MOD_LOADER_VER
 

--- a/CPP/GameAPI/RSDKv5/Game/Object.hpp
+++ b/CPP/GameAPI/RSDKv5/Game/Object.hpp
@@ -123,17 +123,17 @@ struct GameObject {
     };
 
     struct Entity {
-        void Create(void *data){};
-        void Update(){};
-        void Draw(){};
-        void LateUpdate(){};
+        void Create(void *data) {};
+        void Update() {};
+        void Draw() {};
+        void LateUpdate() {};
 #if GAME_INCLUDE_EDITOR
-        void EditorDraw(){};
+        void EditorDraw() {};
 #endif
 
-        static void StageLoad(){};
-        static void Serialize(){};
-        static void StaticUpdate(){};
+        static void StageLoad() {};
+        static void Serialize() {};
+        static void StaticUpdate() {};
 #if RETRO_REV0U
         static void StaticLoad(Static *sVars)
         {
@@ -142,7 +142,7 @@ struct GameObject {
         };
 #endif
 #if GAME_INCLUDE_EDITOR
-        static void EditorLoad(){};
+        static void EditorLoad() {};
 #endif
 
 #if RETRO_REV0U
@@ -340,7 +340,7 @@ struct GameObject {
     static inline uint16 Find(const char *name) { return RSDKTable->FindObject(name); }
 
 #if RETRO_USE_MOD_LOADER
-    static inline void *FindClass(const char *name) { return modTable->FindObject(name); }
+    template <typename T> static inline T *FindClass(const char *name) { return (T *)modTable->FindObject(name); }
 #endif
 
 #if GAME_INCLUDE_EDITOR
@@ -424,7 +424,7 @@ template <typename E> static inline typename E::Static *RegisterObject(typename 
 #endif
 
 #if RETRO_REV0U
-        if (((void (**)(void *)) & E::StaticLoad) != ((void (**)(void *)) & GameObject::Entity::StaticLoad))
+        if (((void (**)(void *))&E::StaticLoad) != ((void (**)(void *))&GameObject::Entity::StaticLoad))
             object->staticLoad = (void (*)(void *))E::StaticLoad;
 #endif
 
@@ -552,7 +552,7 @@ static inline typename E::Static *RegisterObject(typename E::Static **sVars, typ
 #endif
 
 #if RETRO_REV0U
-        if (((void (**)(void *)) & E::StaticLoad) != ((void (**)(void *)) & GameObject::Entity::StaticLoad))
+        if (((void (**)(void *))&E::StaticLoad) != ((void (**)(void *))&GameObject::Entity::StaticLoad))
             object->staticLoad = (void (*)(void *))E::StaticLoad;
 #endif
 

--- a/CPP/GameAPI/RSDKv5/Game/StateMachine.hpp
+++ b/CPP/GameAPI/RSDKv5/Game/StateMachine.hpp
@@ -2,6 +2,7 @@
 
 #include "../Types.hpp"
 #include "Object.hpp"
+#include <cstddef>
 
 #if __clang__
 #pragma clang diagnostic ignored "-Wmicrosoft-cast"
@@ -10,7 +11,7 @@
 namespace RSDK
 {
 #define SET_CURRENT_STATE() RSDK::currentState = __func__
-#define StateMachine_None nullptr
+#define StateMachine_None   nullptr
 
 extern const char *currentState;
 
@@ -114,7 +115,70 @@ template <typename T> struct StateMachine {
         this->state    = u.out;
         this->timer    = duration;
         this->priority = priority;
+        return true;
+    }
 
+    inline bool32 Set(void (*state)(), uint8 priority = PRIORITY_NONE)
+    {
+        if (priority < this->priority || this->priority == PRIORITY_LOCKED)
+            return false;
+
+        union {
+            void (*in)();
+            void (T::*out)();
+        } u;
+        u.in = state;
+
+        this->state    = u.out;
+        this->timer    = 0;
+        this->priority = priority;
+        return true;
+    }
+
+    inline bool32 SetAndRun(void (*state)(), GameObject::Entity *self, uint8 priority = PRIORITY_NONE)
+    {
+        bool32 applied = Set(state, priority);
+        if (applied)
+            Run(self);
+        return applied;
+    }
+
+    inline bool32 QueueForTime(void (*state)(), uint32 duration, uint8 priority = PRIORITY_NONE)
+    {
+        if (priority < this->priority || this->priority == PRIORITY_LOCKED)
+            return false;
+
+        union {
+            void (*in)();
+            void (T::*out)();
+        } u;
+        u.in = state;
+
+        this->state    = u.out;
+        this->timer    = duration;
+        this->priority = priority;
+        return true;
+    }
+
+    inline bool32 Set(std::nullptr_t, uint8 priority = PRIORITY_NONE)
+    {
+        if (priority < this->priority || this->priority == PRIORITY_LOCKED)
+            return false;
+
+        this->state    = nullptr;
+        this->timer    = 0;
+        this->priority = priority;
+        return true;
+    }
+
+    inline bool32 QueueForTime(std::nullptr_t, uint32 duration, uint8 priority = PRIORITY_NONE)
+    {
+        if (priority < this->priority || this->priority == PRIORITY_LOCKED)
+            return false;
+
+        this->state    = nullptr;
+        this->timer    = duration;
+        this->priority = priority;
         return true;
     }
 
@@ -147,7 +211,20 @@ template <typename T> struct StateMachine {
     }
 
     inline bool32 Matches(void (T::*other)()) { return state == other; }
-    template <typename E> inline bool32 Matches(void (E::*other)()) { return state == (void(T::*)())other; }
+
+    template <typename E> inline bool32 Matches(void (E::*other)()) { return state == (void (T::*)())other; }
+
+    inline bool32 Matches(void (*other)())
+    {
+        union {
+            void (*in)();
+            void (T::*out)();
+        } u;
+        u.in = other;
+        return state == u.out;
+    }
+
+    inline bool32 Matches(std::nullptr_t) { return state == nullptr; }
 
     inline void Copy(StateMachine<T> *other)
     {

--- a/CPP/GameAPI/RSDKv5/Game/StateMachine.hpp
+++ b/CPP/GameAPI/RSDKv5/Game/StateMachine.hpp
@@ -118,48 +118,6 @@ template <typename T> struct StateMachine {
         return true;
     }
 
-    inline bool32 Set(void (*state)(), uint8 priority = PRIORITY_NONE)
-    {
-        if (priority < this->priority || this->priority == PRIORITY_LOCKED)
-            return false;
-
-        union {
-            void (*in)();
-            void (T::*out)();
-        } u;
-        u.in = state;
-
-        this->state    = u.out;
-        this->timer    = 0;
-        this->priority = priority;
-        return true;
-    }
-
-    inline bool32 SetAndRun(void (*state)(), GameObject::Entity *self, uint8 priority = PRIORITY_NONE)
-    {
-        bool32 applied = Set(state, priority);
-        if (applied)
-            Run(self);
-        return applied;
-    }
-
-    inline bool32 QueueForTime(void (*state)(), uint32 duration, uint8 priority = PRIORITY_NONE)
-    {
-        if (priority < this->priority || this->priority == PRIORITY_LOCKED)
-            return false;
-
-        union {
-            void (*in)();
-            void (T::*out)();
-        } u;
-        u.in = state;
-
-        this->state    = u.out;
-        this->timer    = duration;
-        this->priority = priority;
-        return true;
-    }
-
     inline bool32 Set(std::nullptr_t, uint8 priority = PRIORITY_NONE)
     {
         if (priority < this->priority || this->priority == PRIORITY_LOCKED)
@@ -180,6 +138,30 @@ template <typename T> struct StateMachine {
         this->timer    = duration;
         this->priority = priority;
         return true;
+    }
+
+    // overloads below are for member function pointer states, keeping the syntax consistent
+    // Say that State_Idle is a public function: .Set(TestObject::State_Idle) -> .Set(&TestObject::State_Idle)
+    inline bool32 Set(void (T::**state)(), uint8 priority = PRIORITY_NONE) { return Set(*state, priority); }
+    inline bool32 SetAndRun(void (T::**state)(), GameObject::Entity *self, uint8 priority = PRIORITY_NONE)
+    {
+        return SetAndRun(*state, self, priority);
+    }
+
+    template <typename E> inline bool32 Set(void (E::**state)(), uint8 priority = PRIORITY_NONE) { return Set(*state, priority); }
+    template <typename E> inline bool32 SetAndRun(void (E::**state)(), GameObject::Entity *self, uint8 priority = PRIORITY_NONE)
+    {
+        return SetAndRun(*state, self, priority);
+    }
+
+    inline bool32 QueueForTime(void (T::**state)(), uint32 duration, uint8 priority = PRIORITY_NONE)
+    {
+        return QueueForTime(*state, duration, priority);
+    }
+
+    template <typename E> inline bool32 QueueForTime(void (E::**state)(), uint32 duration, uint8 priority = PRIORITY_NONE)
+    {
+        return QueueForTime(*state, duration, priority);
     }
 
     inline void Run(GameObject::Entity *self)
@@ -211,18 +193,10 @@ template <typename T> struct StateMachine {
     }
 
     inline bool32 Matches(void (T::*other)()) { return state == other; }
+    inline bool32 Matches(void (T::**other)()) { return ToGenericPtr(state) == ToGenericPtr(*other); }
 
     template <typename E> inline bool32 Matches(void (E::*other)()) { return state == (void (T::*)())other; }
-
-    inline bool32 Matches(void (*other)())
-    {
-        union {
-            void (*in)();
-            void (T::*out)();
-        } u;
-        u.in = other;
-        return state == u.out;
-    }
+    template <typename E> inline bool32 Matches(void (E::**other)()) { return ToGenericPtr(state) == ToGenericPtr(*other); }
 
     inline bool32 Matches(std::nullptr_t) { return state == nullptr; }
 


### PR DESCRIPTION
#### - Mod::GetGlobals is now a template function, returning a  `<T>` pointer instead of `void *`
```cpp
reinterpret_cast<GlobalVariables *>(Mod::GetGlobals()); -> Mod::GetGlobals<GlobalVariables>();
```

#### - GameObject::FindClass is now a template function, returning a `<T>` pointer instead of `void *`
```cpp
TestObject::Static *sVars = reinterpret_cast<TestObject::Static *>(GameObject::FindClass("TestObject"));
sVars->center.x++;
```
```cpp
TestObject::Static *sVars = GameObject::FindClass<TestObject::Static *>("TestObject");
sVars->center.x++;
```

#### - Added a new `Mod::PublicFunctions` namespace
```
Mod::AddPublicFunction  -> Mod::PublicFunctions::Add
Mod::GetPublicFunction  -> Mod::PublicFunctions::Get
Mod::HookPublicFunction -> Mod::PublicFunctions::Hook
```

Which also comes with improvements. The call syntax for `Mod::PublicFunctions::Get` is now similar to the C API and no longer requires manual casting -
```cpp
void (*LogComment)(const char *message) = reinterpret_cast<void(*)(const char*)>(Mod::GetPublicFunction(nullptr, "LogHelpers::LogComment"));
LogComment("Hello");
```
```cpp
void (*LogComment)(const char *message) = Mod::PublicFunctions::Get(nullptr, "LogHelpers::LogComment");
LogComment("Hello");
```

#### - Member functions can now be used as StateHooks
```cpp
bool32 TestObject::State_Idle_Hook(bool32 skippedState)
{
    this->value++;
    return false;
}
```
```cpp
struct TestObject : GameObject::Entity {

    // ...

    // ----------------
    // Entity Variables
    // ----------------

    int32 value;

    // ----------------
    // Public Functions
    // ----------------

    static inline void (TestObject::*State_Idle)() = nullptr;

    // ------------------
    // Object State Hooks
    // ------------------

    bool32 State_Idle_Hook(bool32 skippedState);

    // -------------------
    // Static Declarations
    // -------------------

    MOD_DECLARE(TestObject);
};
```
```cpp
Mod::RegisterStateHook<&TestObject::State_Idle_Hook>(TestObject::State_Idle, true);
```

#### - Added StateMachine function overloads to make it easier for public functions/function pointers to be used as states
```cpp
static inline void (TestObject::*State_Idle)();

this->state.Set(&TestObject::State_Idle);
```

#### - Added support for declaring public function hooks
```cpp
struct Player : GameObject::Entity {

    // ---------------------
    // Public Function Hooks
    // ---------------------

    DECLARE_GAME_HOOK_FUNC("Player::Action_Jump", Action_Jump_Hook, void, Player *player);

    // ^^ the macro above expands to:
    struct Action_Jump_Hook : Mod::PublicFunctions::HookContainer<Action_Jump_Hook> {
        Action_Jump_Hook() : HookContainer(nullptr, "Player::Action_Jump") {}

        static void Implementation(Player *player);
    };

    // if HookContainer is used directly, the constructor can be used as a register callback:
    /*
    Action_Jump_Hook() : HookContainer(nullptr, "Player::Action_Jump") {
        Dev::Print(Dev::PRINT_NORMAL, "Registered Player::Action_Jump");
    }
    */

    // -------------------
    // Static Declarations
    // -------------------

    MOD_DECLARE(Player);
};
```
```cpp
DEFINE_PUBLIC_HOOK_FUNC(Player::Action_Jump_Hook, void, Player *self)
{
    Original(self);

    self->velocity.x += 4 << 16;
    self->velocity.y -= 2 << 16;
}

// direct syntax:
void Player::Action_Jump_Hook::Implementation(Player *self)
{
    Original(self);

    self->velocity.x += 4 << 16;
    self->velocity.y -= 2 << 16;
}
```
```cpp
REGISTER_HOOK_FUNC(Player::Action_Jump_Hook);

// direct syntax:
Player::Action_Jump_Hook::Register();
```