### PR TITLE
Added DECLARE_GAME_FUNC_HOOK macro to the C API

### DIFF
--- a/C/GameAPI/GameLink.h
+++ b/C/GameAPI/GameLink.h
@@ -1996,8 +1996,8 @@ typedef struct {
     static struct {                                                                                                                                  \
         const char *modID;                                                                                                                           \
         const char *name;                                                                                                                            \
-        returnType (*Original)(__VA_ARGS__);                                                                                                         \
-    } type = { _modID, _name };                                                                                                                      \
+    } type##_Info = { _modID, _name };                                                                                                               \
+    extern returnType (*type##_Original)(__VA_ARGS__);                                                                                               \
     returnType type##_Impl(__VA_ARGS__)
 
 // Declare a generic hook, hook into the current game's public functions
@@ -2007,12 +2007,14 @@ typedef struct {
 #define DECLARE_MOD_FUNC_HOOK(modID, name, type, returnType, ...) DECLARE_PUBLIC_FUNC_HOOK(modID, name, type, returnType, __VA_ARGS__)
 
 // Define a generic hook
-#define DEFINE_PUBLIC_FUNC_HOOK(type, returnType, ...) returnType type##_Impl(__VA_ARGS__)
+#define DEFINE_PUBLIC_FUNC_HOOK(type, returnType, ...)                                                                                               \
+    returnType (*type##_Original)(__VA_ARGS__);                                                                                                      \
+    returnType type##_Impl(__VA_ARGS__)
 
 // Register a defined hook of the same name
-#define REGISTER_FUNC_HOOK(type) do { Mod.HookPublicFunction(##type.modID, ##type.name, type##_Impl, (void **)(&##type.Original)); } while (0)
-#endif // !RETRO_MOD_LOADER_VER
-#endif // !RETRO_USE_MOD_LOADER
+#define REGISTER_FUNC_HOOK(type) do { Mod.HookPublicFunction(type##_Info.modID, type##_Info.name, type##_Impl, (void **)(&type##_Original)); } while (0)
+#endif
+#endif
 
 #if RETRO_REV02
 #define RSDK_REGISTER_STATIC_VARIABLES(variables) RSDK.RegisterStaticVariables((void **)&variables, #variables, sizeof(Object##variables))

--- a/C/GameAPI/GameLink.h
+++ b/C/GameAPI/GameLink.h
@@ -1992,7 +1992,7 @@ typedef struct {
 
 #if RETRO_MOD_LOADER_VER >= 3
 // Declare a generic hook
-#define DECLARE_PUBLIC_HOOK_FUNC(_modID, _name, type, returnType, ...)                                                                               \
+#define DECLARE_PUBLIC_FUNC_HOOK(_modID, _name, type, returnType, ...)                                                                               \
     static struct {                                                                                                                                  \
         const char *modID;                                                                                                                           \
         const char *name;                                                                                                                            \
@@ -2001,16 +2001,16 @@ typedef struct {
     returnType type##_Impl(__VA_ARGS__);
 
 // Declare a generic hook, hook into the current game's public functions
-#define DECLARE_GAME_HOOK_FUNC(name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(NULL, name, type, returnType, __VA_ARGS__)
+#define DECLARE_GAME_FUNC_HOOK(name, type, returnType, ...) DECLARE_PUBLIC_FUNC_HOOK(NULL, name, type, returnType, __VA_ARGS__)
 
 // Declare a generic hook, hook into other mods' public functions by ID
-#define DECLARE_MOD_HOOK_FUNC(modID, name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, __VA_ARGS__)
+#define DECLARE_MOD_FUNC_HOOK(modID, name, type, returnType, ...) DECLARE_PUBLIC_FUNC_HOOK(modID, name, type, returnType, __VA_ARGS__)
 
 // Define a generic hook
-#define DEFINE_PUBLIC_HOOK_FUNC(type, returnType, ...) returnType type##_Impl(__VA_ARGS__)
+#define DEFINE_PUBLIC_FUNC_HOOK(type, returnType, ...) returnType type##_Impl(__VA_ARGS__)
 
 // Register a defined hook of the same name
-#define REGISTER_HOOK_FUNC(type) do { Mod.HookPublicFunction(##type.modID, ##type.name, type##_Impl, (void **)(&##type.Original)); } while (0)
+#define REGISTER_FUNC_HOOK(type) do { Mod.HookPublicFunction(##type.modID, ##type.name, type##_Impl, (void **)(&##type.Original)); } while (0)
 #endif // !RETRO_MOD_LOADER_VER
 #endif // !RETRO_USE_MOD_LOADER
 

--- a/C/GameAPI/GameLink.h
+++ b/C/GameAPI/GameLink.h
@@ -1234,10 +1234,10 @@ typedef enum {
 
 #if RETRO_MOD_LOADER_VER >= 3
 typedef enum {
-    RETRO_WIN    = 0,
-    RETRO_PS4    = 1,
-    RETRO_XB1    = 2,
-    RETRO_SWITCH = 3,
+    RETRO_WIN     = 0,
+    RETRO_PS4     = 1,
+    RETRO_XB1     = 2,
+    RETRO_SWITCH  = 3,
     // CUSTOM
     RETRO_OSX     = 4,
     RETRO_LINUX   = 5,
@@ -1248,7 +1248,7 @@ typedef enum {
 } RetroPlatform;
 
 // Opaque pointer to a file descriptor
-typedef void *IOHandle;
+typedef void* IOHandle;
 
 typedef enum {
     IOSEEK_SET = 0, /* Seek from beginning of file. */
@@ -1497,8 +1497,7 @@ typedef struct {
 
     // User File Management
     void (*LoadUserFile)(const char *name, void *buffer, uint32 size, void (*callback)(int32 status)); // load user file from game dir
-    void (*SaveUserFile)(const char *name, void *buffer, uint32 size, void (*callback)(int32 status),
-                         bool32 compressed);                                  // save user file to game dir
+    void (*SaveUserFile)(const char *name, void *buffer, uint32 size, void (*callback)(int32 status), bool32 compressed); // save user file to game dir
     void (*DeleteUserFile)(const char *name, void (*callback)(int32 status)); // delete user file from game dir
 
     // User DBs

--- a/C/GameAPI/GameLink.h
+++ b/C/GameAPI/GameLink.h
@@ -1991,27 +1991,28 @@ typedef struct {
 #define GET_PUBLIC_FUNC(modID, name, returnType, ...) returnType (*name)(__VA_ARGS__) = Mod.GetPublicFunction(modID, #name)
 
 #if RETRO_MOD_LOADER_VER >= 3
+// Declare a generic hook
+#define DECLARE_PUBLIC_HOOK_FUNC(_modID, _name, type, returnType, ...)                                                                               \
+    static struct {                                                                                                                                  \
+        const char *modID;                                                                                                                           \
+        const char *name;                                                                                                                            \
+        returnType (*Original)(__VA_ARGS__);                                                                                                         \
+    } type = { _modID, _name };                                                                                                                      \
+    returnType type##_Impl(__VA_ARGS__);
 
-// Generic hook
-#define DEFINE_PUBLIC_HOOK_FUNC(modID, name, returnType, ...)                        \
-    static returnType (*Original_##name)(__VA_ARGS__);                               \
-    static returnType Hook_##name(__VA_ARGS__);                                      \
-    static void RegisterHook_##name(void) {                                          \
-        Mod.HookPublicFunction(modID, #name, Hook_##name, (void**)&Original_##name); \
-    }                                                                                \
-    static returnType Hook_##name(__VA_ARGS__)
+// Declare a generic hook, hook into the current game's public functions
+#define DECLARE_GAME_HOOK_FUNC(name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(NULL, name, type, returnType, __VA_ARGS__)
 
-// Hook into the current game's public functions
-#define DEFINE_GAME_HOOK_FUNC(name, returnType, ...) DEFINE_PUBLIC_HOOK_FUNC(NULL, name, returnType, __VA_ARGS__)
+// Declare a generic hook, hook into other mods' public functions by ID
+#define DECLARE_MOD_HOOK_FUNC(modID, name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, __VA_ARGS__)
 
-// Hook into other mods' public functions by ID
-#define DEFINE_MOD_HOOK_FUNC(modID, name, returnType, ...) DEFINE_PUBLIC_HOOK_FUNC(modID, name, returnType, __VA_ARGS__)
+// Define a generic hook
+#define DEFINE_PUBLIC_HOOK_FUNC(type, returnType, ...) returnType type##_Impl(__VA_ARGS__)
 
 // Register a defined hook of the same name
-#define REGISTER_HOOK_FUNC(name) do { RegisterHook_##name(); } while (0)
-
-#endif
-#endif
+#define REGISTER_HOOK_FUNC(type) do { Mod.HookPublicFunction(##type.modID, ##type.name, type##_Impl, (void **)(&##type.Original)); } while (0)
+#endif // !RETRO_MOD_LOADER_VER
+#endif // !RETRO_USE_MOD_LOADER
 
 #if RETRO_REV02
 #define RSDK_REGISTER_STATIC_VARIABLES(variables) RSDK.RegisterStaticVariables((void **)&variables, #variables, sizeof(Object##variables))

--- a/C/GameAPI/GameLink.h
+++ b/C/GameAPI/GameLink.h
@@ -1998,7 +1998,7 @@ typedef struct {
         const char *name;                                                                                                                            \
         returnType (*Original)(__VA_ARGS__);                                                                                                         \
     } type = { _modID, _name };                                                                                                                      \
-    returnType type##_Impl(__VA_ARGS__);
+    returnType type##_Impl(__VA_ARGS__)
 
 // Declare a generic hook, hook into the current game's public functions
 #define DECLARE_GAME_FUNC_HOOK(name, type, returnType, ...) DECLARE_PUBLIC_FUNC_HOOK(NULL, name, type, returnType, __VA_ARGS__)

--- a/C/GameAPI/GameLink.h
+++ b/C/GameAPI/GameLink.h
@@ -97,7 +97,7 @@ typedef uint32 color;
 #define FABS(a)                        ((a) > 0 ? (a) : -(a))
 
 #define SET_BIT(value, set, pos) ((value) ^= (-(int32)(set) ^ (value)) & (1 << (pos)))
-#define GET_BIT(b, pos)          ((b) >> (pos)&1)
+#define GET_BIT(b, pos)          ((b) >> (pos) & 1)
 
 #define INT_TO_VOID(x)   (void *)(size_t)(x)
 #define FLOAT_TO_VOID(x) INT_TO_VOID(*(int32 *)&(x))
@@ -110,7 +110,7 @@ typedef uint32 color;
 #define FROM_FIXED(x) ((x) >> 16)
 
 // floating point variants
-#define TO_FIXED_F(x)   ((x)*65536.0)
+#define TO_FIXED_F(x)   ((x) * 65536.0)
 #define FROM_FIXED_F(x) ((x) / 65536.0)
 
 #define RSDK_PI (3.1415927f)
@@ -1234,10 +1234,10 @@ typedef enum {
 
 #if RETRO_MOD_LOADER_VER >= 3
 typedef enum {
-    RETRO_WIN     = 0,
-    RETRO_PS4     = 1,
-    RETRO_XB1     = 2,
-    RETRO_SWITCH  = 3,
+    RETRO_WIN    = 0,
+    RETRO_PS4    = 1,
+    RETRO_XB1    = 2,
+    RETRO_SWITCH = 3,
     // CUSTOM
     RETRO_OSX     = 4,
     RETRO_LINUX   = 5,
@@ -1248,7 +1248,7 @@ typedef enum {
 } RetroPlatform;
 
 // Opaque pointer to a file descriptor
-typedef void* IOHandle;
+typedef void *IOHandle;
 
 typedef enum {
     IOSEEK_SET = 0, /* Seek from beginning of file. */
@@ -1497,7 +1497,8 @@ typedef struct {
 
     // User File Management
     void (*LoadUserFile)(const char *name, void *buffer, uint32 size, void (*callback)(int32 status)); // load user file from game dir
-    void (*SaveUserFile)(const char *name, void *buffer, uint32 size, void (*callback)(int32 status), bool32 compressed); // save user file to game dir
+    void (*SaveUserFile)(const char *name, void *buffer, uint32 size, void (*callback)(int32 status),
+                         bool32 compressed);                                  // save user file to game dir
     void (*DeleteUserFile)(const char *name, void (*callback)(int32 status)); // delete user file from game dir
 
     // User DBs
@@ -1716,7 +1717,7 @@ typedef struct {
     uint16 (*GetTile)(uint16 layer, int32 x, int32 y);
     void (*SetTile)(uint16 layer, int32 x, int32 y, uint16 tile);
     void (*CopyTileLayer)(uint16 dstLayerID, int32 dstStartX, int32 dstStartY, uint16 srcLayerID, int32 srcStartX, int32 srcStartY, int32 countX,
-                           int32 countY);
+                          int32 countY);
     void (*ProcessParallax)(TileLayer *tileLayer);
     ScanlineInfo *(*GetScanlines)(void);
 
@@ -1992,27 +1993,25 @@ typedef struct {
 
 #if RETRO_MOD_LOADER_VER >= 3
 // Declare a generic hook
-#define DECLARE_PUBLIC_FUNC_HOOK(_modID, _name, type, returnType, ...)                                                                               \
-    static struct {                                                                                                                                  \
-        const char *modID;                                                                                                                           \
-        const char *name;                                                                                                                            \
-    } type##_Info = { _modID, _name };                                                                                                               \
+#define DECLARE_PUBLIC_FUNC_HOOK(type, returnType, ...)                                                                                              \
+    void type##_Register(void);                                                                                                                      \
     extern returnType (*type##_Original)(__VA_ARGS__);                                                                                               \
     returnType type##_Impl(__VA_ARGS__)
 
-// Declare a generic hook, hook into the current game's public functions
-#define DECLARE_GAME_FUNC_HOOK(name, type, returnType, ...) DECLARE_PUBLIC_FUNC_HOOK(NULL, name, type, returnType, __VA_ARGS__)
-
-// Declare a generic hook, hook into other mods' public functions by ID
-#define DECLARE_MOD_FUNC_HOOK(modID, name, type, returnType, ...) DECLARE_PUBLIC_FUNC_HOOK(modID, name, type, returnType, __VA_ARGS__)
-
 // Define a generic hook
-#define DEFINE_PUBLIC_FUNC_HOOK(type, returnType, ...)                                                                                               \
+#define DEFINE_PUBLIC_FUNC_HOOK(modID, name, type, returnType, ...)                                                                                  \
+    void type##_Register() { Mod.HookPublicFunction(modID, name, type##_Impl, (void **)(&type##_Original)); }                                        \
     returnType (*type##_Original)(__VA_ARGS__);                                                                                                      \
     returnType type##_Impl(__VA_ARGS__)
 
+// Define a function hook, hook into the current game's public functions
+#define DEFINE_GAME_FUNC_HOOK(name, type, returnType, ...) DEFINE_PUBLIC_FUNC_HOOK(NULL, name, type, returnType, __VA_ARGS__)
+
+// Define a function hook, hook into other mods' public functions by ID
+#define DEFINE_MOD_FUNC_HOOK(modID, name, type, returnType, ...) DEFINE_PUBLIC_FUNC_HOOK(modID, name, type, returnType, __VA_ARGS__)
+
 // Register a defined hook of the same name
-#define REGISTER_FUNC_HOOK(type) do { Mod.HookPublicFunction(type##_Info.modID, type##_Info.name, type##_Impl, (void **)(&type##_Original)); } while (0)
+#define REGISTER_FUNC_HOOK(type) type##_Register()
 #endif
 #endif
 

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -284,23 +284,23 @@ extern const char *modID;
 
 #if RETRO_MOD_LOADER_VER >= 3
 // Declare a generic hook
-#define DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, ...)                                                                                 \
-    struct type : RSDK::Mod::PublicFunctions::HookContainer<type> {                                                                                        \
+#define DECLARE_PUBLIC_FUNC_HOOK(modID, name, type, returnType, ...)                                                                                 \
+    struct type : RSDK::Mod::PublicFunctions::HookContainer<type> {                                                                                  \
         type() : HookContainer(name, modID) {}                                                                                                       \
-        static returnType Impl(__VA_ARGS__);                                                                                               \
+        static returnType Impl(__VA_ARGS__);                                                                                                         \
     };
 
 // Declare a generic hook, hook into the current game's public functions
-#define DECLARE_GAME_HOOK_FUNC(name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(nullptr, name, type, returnType, __VA_ARGS__)
+#define DECLARE_GAME_FUNC_HOOK(name, type, returnType, ...) DECLARE_PUBLIC_FUNC_HOOK(nullptr, name, type, returnType, __VA_ARGS__)
 
 // Declare a generic hook, hook into other mods' public functions by ID
-#define DECLARE_MOD_HOOK_FUNC(modID, name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, __VA_ARGS__)
+#define DECLARE_MOD_FUNC_HOOK(modID, name, type, returnType, ...) DECLARE_PUBLIC_FUNC_HOOK(modID, name, type, returnType, __VA_ARGS__)
 
 // Define a generic hook
-#define DEFINE_PUBLIC_HOOK_FUNC(name, returnType, ...) returnType name::Impl(__VA_ARGS__)
+#define DEFINE_PUBLIC_FUNC_HOOK(name, returnType, ...) returnType name::Impl(__VA_ARGS__)
 
 // Register a defined hook of the same name
-#define REGISTER_HOOK_FUNC(name) name::Register()
+#define REGISTER_FUNC_HOOK(name) name::Register()
 
 #endif // !RETRO_MOD_LOADER_VER
 

--- a/CPP/GameAPI/RSDKv5/API/Mod.hpp
+++ b/CPP/GameAPI/RSDKv5/API/Mod.hpp
@@ -127,12 +127,12 @@ public:
     static void Register()
     {
         Derived instance = {};
-        PublicFunctions::Hook(instance.modID__, instance.name__, reinterpret_cast<void *>(&Derived::Implementation), reinterpret_cast<void **>(&instance.original__));
+        PublicFunctions::Hook(instance.modID__, instance.name__, reinterpret_cast<void *>(&Derived::Impl), reinterpret_cast<void **>(&instance.original__));
     }
 
     template <typename... Args> static decltype(auto) Original(Args &&...args)
     {
-        using T = decltype(&std::remove_reference_t<Derived>::Implementation);
+        using T = decltype(&std::remove_reference_t<Derived>::Impl);
 
         T _original = reinterpret_cast<T>(original__);
         return _original(std::forward<Args>(args)...);
@@ -287,7 +287,7 @@ extern const char *modID;
 #define DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, ...)                                                                                 \
     struct type : RSDK::Mod::PublicFunctions::HookContainer<type> {                                                                                        \
         type() : HookContainer(name, modID) {}                                                                                                       \
-        static returnType Implementation(__VA_ARGS__);                                                                                               \
+        static returnType Impl(__VA_ARGS__);                                                                                               \
     };
 
 // Declare a generic hook, hook into the current game's public functions
@@ -297,7 +297,7 @@ extern const char *modID;
 #define DECLARE_MOD_HOOK_FUNC(modID, name, type, returnType, ...) DECLARE_PUBLIC_HOOK_FUNC(modID, name, type, returnType, __VA_ARGS__)
 
 // Define a generic hook
-#define DEFINE_PUBLIC_HOOK_FUNC(name, returnType, ...) returnType name::Implementation(__VA_ARGS__)
+#define DEFINE_PUBLIC_HOOK_FUNC(name, returnType, ...) returnType name::Impl(__VA_ARGS__)
 
 // Register a defined hook of the same name
 #define REGISTER_HOOK_FUNC(name) name::Register()


### PR DESCRIPTION
Renamed `DECLARE_GAME_HOOK_FUNC` -> `DECLARE_GAME_FUNC_HOOK` (along with the other ones), and added said macro to the C API to allow referencing and registering public function hooks without them strictly being visible to their source files.
```c
DEFINE_PUBLIC_FUNC_HOOK("TestObject_Function", TestObject_Function, void, const char *message)
{
    TestObject_Function_Original("hello!");
    TestObject_Function_Original(message);
}
```
```c
DECLARE_GAME_FUNC_HOOK(TestObject_Function, void, const char *message);
```